### PR TITLE
Replaces generated rss relative paths with absolute URLs.

### DIFF
--- a/layouts/atom.xml
+++ b/layouts/atom.xml
@@ -10,14 +10,16 @@
   <generator>ipsumgenera</generator>
   <updated>${getTime().getGMTime().format("yyyy-MM-dd'T'HH:mm:ss'Z'")}</updated>
 # for a in meta:
+# let absoluteUrl = joinUrl(url, genURL(a))
+# let absoluteBase = splitPath(absoluteUrl).head
     <entry>
       <title>${a.title}</title>
-      <link rel="alternate" type="text/html" href="${joinUrl(url, genURL(a))}"/>
-      <id>${joinUrl(url, genURL(a))}</id>
+      <link rel="alternate" type="text/html" href="${absoluteUrl}"/>
+      <id>${absoluteUrl}</id>
       <updated>${a.date.format("yyyy-MM-dd'T'HH:mm:ss'Z'")}</updated>
       <author><name>${author}</name></author>
       <content type="html">
-        ${xmltree.escape(renderRst(a.body, url))}
+        ${xmltree.escape(renderRst(a.body, url, absoluteUrls = absoluteBase))}
       </content>
     </entry>
 # end for


### PR DESCRIPTION
Looking around rss readers it seems like `xml:base` is a future nice proposal to make relative links work, but in the meantime the only solid solution is to use absolute urls for everything in an rss feed. The generated URLs aren't pretty as seen in https://github.com/gradha/gradha.github.io/commit/cae47f0ccaa7f47cf139118a19e96fbfecb8507a since they could be normalized and shortened a little, but at least they are functional.
