### PR TITLE
Escapes better local file paths in rss IRIs.

### DIFF
--- a/layouts/atom.xml
+++ b/layouts/atom.xml
@@ -10,11 +10,11 @@
   <generator>ipsumgenera</generator>
   <updated>${getTime().getGMTime().format("yyyy-MM-dd'T'HH:mm:ss'Z'")}</updated>
 # for a in meta:
-# let absoluteUrl = joinUrl(url, genURL(a))
+# let absoluteUrl = joinUrl(url, escapePath(genURL(a)))
 # let absoluteBase = splitPath(absoluteUrl).head
     <entry>
       <title>${a.title}</title>
-      <link rel="alternate" type="text/html" href="${joinUrl(url, genURL(a))}"/>
+      <link rel="alternate" type="text/html" href="${absoluteUrl}"/>
       <id>${absoluteUrl}</id>
       <published>${a.pubDate.format("yyyy-MM-dd'T'HH:mm:ss'Z'")}</published>
       <updated>${a.modDate.format("yyyy-MM-dd'T'HH:mm:ss'Z'")}</updated>


### PR DESCRIPTION
Example of corrected content in https://github.com/gradha/gradha.github.io/commit/1feda2b2fda46a3768deea0310e4ec43c9b2033a.
