### PR TITLE
update pass to work with stable nim

### DIFF
--- a/ipsumgenera.nimble
+++ b/ipsumgenera.nimble
@@ -1,8 +1,8 @@
-[Package]
-name          = "ipsumgenera"
-version       = "0.1.0"
+version       = "0.1.1"
 author        = "Dominik Picheta"
 description   = "A static blog generator."
 license       = "MIT"
+srcDir        = "src"
+bin           = @["ipsum"]
 
-bin = "ipsum"
+requires "nim >= 0.19.4"

--- a/layouts/article.html
+++ b/layouts/article.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+<title>${title}</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+</head>
+<body>
+${body}
+<hr>
+<p>Last update: ${modDate}</p>
+</body>
+</html>

--- a/layouts/articles.html
+++ b/layouts/articles.html
@@ -1,6 +1,5 @@
-#! stdtmpl
+#? stdtmpl(subsChar = '$', metaChar = '#')
 #proc renderArticles(articles: seq[TArticleMetadata], prefix: string): string =
-#  result = ""
 <table id="articles">
 #  for a in articles:
     <tr>
@@ -12,7 +11,6 @@
 #end proc
 #
 #proc renderTags(tags: seq[string], prefix: string): string =
-#  result = ""
 #  for i in 0..tags.len-1:
     <a href="${prefix}tags/${tags[i].normalizeTag}.html">${tags[i]}</a>
     ${if i < tags.len-1: "," else: ""}

--- a/layouts/atom.xml
+++ b/layouts/atom.xml
@@ -1,6 +1,5 @@
-#! stdtmpl
+#? stdtmpl(subsChar = '$', metaChar = '#')
 #proc renderAtom(meta: seq[TArticleMetadata], title, url, feedUrl, author: string): string =
-#   result = ""
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title>${title}</title>
@@ -8,7 +7,7 @@
   <link href="${feedUrl}" rel="self" />
   <id>${url}</id>
   <generator>ipsumgenera</generator>
-  <updated>${getTime().getGMTime().format("yyyy-MM-dd'T'HH:mm:ss'Z'")}</updated>
+  <updated>${getTime().utc().format("yyyy-MM-dd'T'HH:mm:ss'Z'")}</updated>
 # for a in meta:
 # let absoluteUrl = joinUrl(url, escapePath(genURL(a)))
 # let absoluteBase = splitPath(absoluteUrl).head

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<title>A default page</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+</head>
+<body>
+${body}
+</body>
+</html>

--- a/layouts/static.html
+++ b/layouts/static.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+<title>${title}</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+</head>
+<body>
+${body}
+<hr>
+<p>Last update: ${modDate}</p>
+</body>
+</html>

--- a/layouts/tag.html
+++ b/layouts/tag.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<title>A tag.html title: ${tag}</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+</head>
+<body>
+${body}
+</body>
+</html>

--- a/src/config.nim
+++ b/src/config.nim
@@ -15,7 +15,7 @@ proc initConfig(): TConfig =
 
 proc validateConfig(config: TConfig) =
   template ra(field: string) =
-    raise newException(EInvalidValue,
+    raise newException(ValueError,
       "You need to specify the '$1' field in the config." % field)
   if config.title == "":
     ra("title")
@@ -24,21 +24,21 @@ proc validateConfig(config: TConfig) =
   if config.url == "":
     ra("url")
   if config.numRssEntries < 0:
-    raise newException(EInvalidValue,
+    raise newException(ValueError,
       "The numRssEntries value can't be negative.")
 
 proc parseConfig*(filename: string): TConfig =
   if not filename.existsFile:
-    raise newException(EInvalidValue, "Missing '" & filename & "'")
+    raise newException(ValueError, "Missing '" & filename & "'")
   result = initConfig()
   var file = newFileStream(filename, fmRead)
-  var cfg: TCfgParser
+  var cfg: CfgParser
   open(cfg, file, filename)
   while true:
     let ev = cfg.next()
     case ev.kind
     of cfgSectionStart:
-      raise newException(EInvalidValue, "No sections supported.")
+      raise newException(ValueError, "No sections supported.")
     of cfgKeyValuePair, cfgOption:
       case ev.key.normalize
       of "title":
@@ -50,7 +50,7 @@ proc parseConfig*(filename: string): TConfig =
       of "numrssentries":
         result.numRssEntries = ev.value.parseInt
     of cfgError:
-      raise newException(EInvalidValue, ev.msg)
+      raise newException(ValueError, ev.msg)
     of cfgEof:
       break
   cfg.close()

--- a/src/metadata.nim
+++ b/src/metadata.nim
@@ -15,7 +15,6 @@ type
     pubDate: bool
     modDate: bool
     tags: bool
-    isDraft: bool
     body: bool
 
 proc parseDate(val: string): DateTime =
@@ -68,7 +67,7 @@ proc parseMetadata*(filename: string): TArticleMetadata =
         meta.data.tags.add(i.strip)
     of "draft":
       let vn = value.normalize
-      isDraft := vn in ["t", "true", "y", "yes"]
+      meta.data.isDraft = vn in ["t", "true", "y", "yes"]
     else:
       raise newException(ValueError, "Unknown key: " & key)
   i.inc 3 # skip ---
@@ -78,5 +77,5 @@ proc parseMetadata*(filename: string): TArticleMetadata =
   if not meta.modDate:
     modDate := filename.getLastModificationTime.utc
 
-  doAssert(meta.progress == 6 or (meta.progress == 5 and not meta.isDraft))
+  doAssert(meta.progress == 5)
   return meta.data

--- a/src/metadata.nim
+++ b/src/metadata.nim
@@ -3,45 +3,37 @@ import strutils, times, parseutils, os
 type
   TArticleMetadata* = object
     title*: string
-    pubDate*: TTimeInfo
-    modDate*: TTimeInfo
+    pubDate*: DateTime
+    modDate*: DateTime
     tags*: seq[string]
     isDraft*: bool
     body*: string
+  MetadataInProgress = object
+    data: TArticleMetadata
+    progress: int
+    title: bool
+    pubDate: bool
+    modDate: bool
+    tags: bool
+    isDraft: bool
+    body: bool
 
-proc parseDate(val: string): TTimeInfo =
-  # YYYY-mm-dd hh:mm
-  var i = 0
-  var
-    year = ""
-    month = ""
-    day = ""
-    hour = ""
-    minute = ""
-  i.inc parseUntil(val, year, '-', i)
-  i.inc
-  i.inc parseUntil(val, month, '-', i)
-  i.inc
-  i.inc parseUntil(val, day, ' ', i)
-  i.inc
-  i.inc parseUntil(val, hour, ':', i)
-  i.inc
-  minute = val[i .. -1]
-  result.year = parseInt(year)
-  result.month = (parseInt(month)-1).TMonth
-  result.monthday = parseInt(day)
-  result.hour = parseInt(hour)
-  result.minute = parseInt(minute)
-  result.tzname = "UTC"
-  let t = TimeInfoToTime(result)
-  result = getGMTime(t)
+proc parseDate(val: string): DateTime =
+  parse(val, "yyyy-MM-dd HH:mm:ss", utc())
 
 proc parseMetadata*(filename: string): TArticleMetadata =
+  var meta = MetadataInProgress(data: TArticleMetadata(pubDate: now(), modDate: now()))
+  template `:=`(a, b: untyped): untyped =
+    assert(not meta.a)
+    meta.data.a = b
+    meta.a = true
+    inc meta.progress
+
   let article = readFile(filename)
   var i = 0
   i.inc skip(article, "---", i)
   if i == 0:
-    raise newException(EInvalidValue,
+    raise newException(ValueError,
           "Article must begin with '---' signifying meta data.")
   i.inc skipWhitespace(article, i)
   while true:
@@ -54,7 +46,7 @@ proc parseMetadata*(filename: string): TArticleMetadata =
     var key = ""
     i.inc parseUntil(article, key, {':'} + Whitespace, i)
     if article[i] != ':':
-      raise newException(EInvalidValue, "Expected ':' after key in meta data.")
+      raise newException(ValueError, "Expected ':' after key in meta data.")
     i.inc # skip :
     i.inc skipWhitespace(article, i)
     
@@ -63,26 +55,28 @@ proc parseMetadata*(filename: string): TArticleMetadata =
     i.inc skipWhitespace(article, i)
     case key.normalize
     of "title":
-      result.title = value
-      if result.title[0] == '"' and result.title[result.title.len-1] == '"':
-        result.title = result.title[1 .. -2]
+      if value[0] == '"' and value[^1] == '"':
+        value = value[1 .. ^2]
+      title := value
     of "date", "pubdate":
-      result.pubDate = parseDate(value)
+      pubDate := parseDate(value)
     of "moddate":
-      result.modDate = parseDate(value)
+      modDate := parseDate(value)
     of "tags":
-      result.tags = @[]
+      tags := @[]
       for i in value.split(','):
-        result.tags.add(i.strip)
+        meta.data.tags.add(i.strip)
     of "draft":
       let vn = value.normalize
-      result.isDraft = vn in ["t", "true", "y", "yes"]
+      isDraft := vn in ["t", "true", "y", "yes"]
     else:
-      raise newException(EInvalidValue, "Unknown key: " & key)
+      raise newException(ValueError, "Unknown key: " & key)
   i.inc 3 # skip ---
   i.inc skipWhitespace(article, i)
-  result.body = article[i .. -1]
-  if result.tags.isNil: result.tags = @[]
+  body := article[i .. ^1]
   # Give last modification date as file timestamp if nothing else was found.
-  if result.modDate.year == 0:
-    result.modDate = filename.getLastModificationTime.getGMTime
+  if not meta.modDate:
+    modDate := filename.getLastModificationTime.utc
+
+  doAssert(meta.progress == 6 or (meta.progress == 5 and not meta.isDraft))
+  return meta.data


### PR DESCRIPTION
necessary and sufficient changes:
- `a .. -b` to `a .. ^b`
- `EInvalidValue` to `ValueError`, `EOS` to `OSError`, etc.
- `times.toSeconds` to `times.toUnix` and `float` to `int64`
- use current source filters
- rename .babel file to match project
- remove `isNil` checks against string results
- zero-byte "end of string" test replaced with length. that's for `cstring` now.
- rst imports now from packages/docutils

sufficient changes:
- support unicode tags
- unidecode title slug
- implement `parseDate` with `times.parse`

other changes:
- `a .. <b`to `a ..< b`
- change .babel to .nimble
- move main .nim to src/ and update paths
- deleted now-unnecessary initialization of `result` when noticed
- add layouts to ipsum itself.
- Nim complained that `parseMetadata` might not initialize its result, and that this would one day be an error. Added `MetadataInProgress` and used scoped template to ensure initialization (maybe more for my satisfaction than for Nim's in the end)